### PR TITLE
Mouse and Button properties for a Tap

### DIFF
--- a/API.md
+++ b/API.md
@@ -115,7 +115,7 @@ function update() {    requestAnimationFrame(update);    // update taps on ea
 | dragend | <code>boolean</code> | True when tap is ended dragging. It will be in that state only if previously was in `dragstart`, and tap will be removed after. |
 | timestamp | <code>boolean</code> | Milliseconds timestamp of when tap has started. |
 | mouse | <code>boolean</code> | True when tap originated from mouse input. |
-| button | <code>number</code> | A button number of a mouse that tap originated from. |
+| button | <code>null</code> \| <code>number</code> | If originated from mouse, a button number, otherwise null. |
 | x | <code>number</code> | X current coordinate of a tap, where 0 - is left. |
 | y | <code>number</code> | Y current coordinate of a tap, where 0 - is top. |
 | sx | <code>number</code> | X coordinate of where tap started. |

--- a/API.md
+++ b/API.md
@@ -114,6 +114,8 @@ function update() {    requestAnimationFrame(update);    // update taps on ea
 | drag | <code>boolean</code> | True when tap is dragging. It will be in that state from `dragstart` till the end of a tap. |
 | dragend | <code>boolean</code> | True when tap is ended dragging. It will be in that state only if previously was in `dragstart`, and tap will be removed after. |
 | timestamp | <code>boolean</code> | Milliseconds timestamp of when tap has started. |
+| mouse | <code>boolean</code> | True when tap originated from mouse input. |
+| button | <code>number</code> | A button number of a mouse that tap originated from. |
 | x | <code>number</code> | X current coordinate of a tap, where 0 - is left. |
 | y | <code>number</code> | Y current coordinate of a tap, where 0 - is top. |
 | sx | <code>number</code> | X coordinate of where tap started. |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ for(const tap of taps.click) {
 }
 ```
 
+Unique to mouse properties are also available:
+
+```js
+for(const tap of taps) {
+    if (tap.mouse && tap.button === 0) {
+        // applies to only taps originated from mouse
+        // and only from left mouse button
+    }
+}
+```
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mr-tap",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A tap library, abstracts away from mouse/touch providing source agnostic sync access to the user input.",
   "type": "module",
   "main": "src/index.js",

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -18,7 +18,8 @@ class TapMouse {
     }
 
     _onMouseDown(evt) {
-        const tap = new Tap(this._taps, -1);
+        const id = -evt.button - 1;
+        const tap = new Tap(this._taps, id);
         this._taps._index.set(tap.id, tap);
         tap.change(evt);
         tap._sx = tap._lx = tap._x;
@@ -26,13 +27,15 @@ class TapMouse {
     }
 
     _onMouseMove(evt) {
-        const tap = this._taps._index.get(-1);
-        if (! tap) return;
-        tap.change(evt);
+        for(const tap of this._taps._index.values()) {
+            if (! tap.mouse) continue;
+            tap.change(evt);
+        }
     }
 
     _onMouseUp(evt) {
-        const tap = this._taps._index.get(-1);
+        const id = -evt.button - 1;
+        const tap = this._taps._index.get(id);
         if (! tap) return;
         tap.change(evt);
         tap._release = true;

--- a/src/tap.js
+++ b/src/tap.js
@@ -10,7 +10,7 @@
  * @property {boolean} dragend True when tap is ended dragging. It will be in that state only if previously was in `dragstart`, and tap will be removed after.
  * @property {boolean} timestamp Milliseconds timestamp of when tap has started.
  * @property {boolean} mouse True when tap originated from mouse input.
- * @property {number} button A button number of a mouse that tap originated from.
+ * @property {null|number} button If originated from mouse, a button number, otherwise null.
  * @property {number} x X current coordinate of a tap, where 0 - is left.
  * @property {number} y Y current coordinate of a tap, where 0 - is top.
  * @property {number} sx X coordinate of where tap started.
@@ -75,7 +75,7 @@ class Tap {
         this._dy = 0;
 
         this._mouse = false;
-        this._button = 0;
+        this._button = null;
 
         this._start = true;
         this._started = false;

--- a/src/tap.js
+++ b/src/tap.js
@@ -9,6 +9,8 @@
  * @property {boolean} drag True when tap is dragging. It will be in that state from `dragstart` till the end of a tap.
  * @property {boolean} dragend True when tap is ended dragging. It will be in that state only if previously was in `dragstart`, and tap will be removed after.
  * @property {boolean} timestamp Milliseconds timestamp of when tap has started.
+ * @property {boolean} mouse True when tap originated from mouse input.
+ * @property {number} button A button number of a mouse that tap originated from.
  * @property {number} x X current coordinate of a tap, where 0 - is left.
  * @property {number} y Y current coordinate of a tap, where 0 - is top.
  * @property {number} sx X coordinate of where tap started.
@@ -71,6 +73,9 @@ class Tap {
 
         this._dx = 0;
         this._dy = 0;
+
+        this._mouse = false;
+        this._button = 0;
 
         this._start = true;
         this._started = false;
@@ -165,6 +170,14 @@ class Tap {
 
     get timestamp() {
         return this._timestamp;
+    }
+
+    get mouse() {
+        return this._mouse;
+    }
+
+    get button() {
+        return this._button;
     }
 
     get x() {


### PR DESCRIPTION
When Tap originates from mouse input, it can be useful to identify such cases. So progressively apps can use the button property to apply logic to e.g.: only the right mouse button.